### PR TITLE
Implement Word Highlighting in Chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "zxc-roomba",
+  "name": "PS-Bot",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,4 +26,5 @@ export const config = {
     hostRoom: __config.hostRoom ?? 'botdevelopment',
     imageCDN: __config.imageCDN ?? 'https://cdn.crob.at/',
     name: process.env.botusername,
+    discordId: process.env.discord_id,
 };

--- a/src/db.ts
+++ b/src/db.ts
@@ -8,6 +8,7 @@ db.serialize(() => {
     db.run('CREATE TABLE IF NOT EXISTS apologies (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, points INTEGER)');
     db.run('CREATE TABLE IF NOT EXISTS pc (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT,  economic REAL, social REAL)');
     db.run('CREATE TABLE IF NOT EXISTS mysterybox (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, points INTEGER)');
+    db.run('CREATE TABLE IF NOT EXISTS word_highlights (id INTEGER PRIMARY KEY AUTOINCREMENT, user TEXT NOT NULL, discord_id TEXT NOT NULL, word TEXT NOT NULL, created_at DATETIME DEFAULT CURRENT_TIMESTAMP)');
 });
 
 export default db;

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { hook } from './hook.js';
 import { MBaddPoints, MBanswerQuestion, MBgetAnswers, MBleaderboard, MBrank, MBcreateQuestion, MBshowAnswerBox, MBtestAuth, leaderboard, MBendQuestion, MBdeclareQuestion } from './mods/mysterybox.js';
 import { toID } from 'ps-client/tools.js';
 import { assertNever, isRoom, toCmd } from './utils.js';
+import { addHighlight, checkHighlights, listHighlights, removeHighlight } from './mods/wordHighlight.js';
 
 import express from 'express';
 import morgan from 'morgan';
@@ -29,6 +30,7 @@ client.on('message', (message) => {
     logger.verbose({ cmd: 'chat', message: message.content, username, target });
     saveChat(message, username);
     apologyCounter(message, username);
+    checkHighlights(message, username);
 
     // Not voice
     if (message.msgRank !== ' ' && message.msgRank !== undefined) {
@@ -173,6 +175,21 @@ client.on('message', (message) => {
         case 'pcall':
             if (!config.whitelist.includes(username)) return;
             showCombinedPoliticalCompass(message);
+            break;
+
+        case 'addhighlight':
+        case 'highlight':
+            addHighlight(message);
+            break;
+
+        case 'removehighlight':
+        case 'delhighlight':
+            removeHighlight(message);
+            break;
+
+        case 'listhighlight':
+        case 'highlights':
+            listHighlights(message);
             break;
 
         default:

--- a/src/main.ts
+++ b/src/main.ts
@@ -179,16 +179,19 @@ client.on('message', (message) => {
 
         case 'addhighlight':
         case 'highlight':
+            if (!config.whitelist.includes(username)) return;
             addHighlight(message);
             break;
 
         case 'removehighlight':
         case 'delhighlight':
+            if (!config.whitelist.includes(username)) return;
             removeHighlight(message);
             break;
 
         case 'listhighlight':
         case 'highlights':
+            if (!config.whitelist.includes(username)) return;
             listHighlights(message);
             break;
 

--- a/src/mods/wordHighlight.ts
+++ b/src/mods/wordHighlight.ts
@@ -1,0 +1,185 @@
+import type { Message } from 'ps-client';
+import db from '../db.js';
+import { reply } from '../bot.js';
+import { hook } from '../hook.js';
+import { logger } from '../logger.js';
+import { toID } from 'ps-client/tools.js';
+
+interface Highlight {
+    user: string;
+    discord_id: string;
+    word: string;
+}
+
+/**
+ * Check messages for highlighted words and send Discord notifications
+ */
+export function checkHighlights(message: Message<'chat' | 'pm'>, authorUsername: string) {
+    const content = message.content.toLowerCase();
+
+    // Get all highlights from database
+    db.all('SELECT user, discord_id, word FROM word_highlights', (err: Error | null, rows: Highlight[]) => {
+        if (err) {
+            logger.error({ cmd: 'checkHighlights', error: err.message });
+            return;
+        }
+
+        for (const highlight of rows) {
+            // Don't highlight user's own messages
+            if (toID(highlight.user) === authorUsername) continue;
+
+            // Check if the word is in the message (case-insensitive, whole word match)
+            const wordRegex = new RegExp(`\\b${escapeRegex(highlight.word)}\\b`, 'i');
+            if (wordRegex.test(content)) {
+                // Send Discord notification
+                const roomInfo = message.target instanceof Object && 'roomid' in message.target
+                    ? `room: ${message.target.roomid}`
+                    : 'PM';
+
+                hook.send(`<@${highlight.discord_id}> Your highlight word "${highlight.word}" was mentioned by ${message.author?.name} in ${roomInfo}: "${message.content}"`);
+
+                logger.info({
+                    cmd: 'wordHighlight',
+                    user: highlight.user,
+                    word: highlight.word,
+                    author: message.author?.name,
+                    content: message.content
+                });
+            }
+        }
+    });
+}
+
+/**
+ * Add a word to highlight for the current user
+ */
+export function addHighlight(message: Message<'chat' | 'pm'>) {
+    // Parse command: #addhighlight <discord_id> <word>
+    const parts = message.content.split(' ');
+
+    if (parts.length < 3) {
+        reply(message, 'Usage: addhighlight <discord_id> <word>. Example: addhighlight 123456789 pizza');
+        return;
+    }
+
+    const discordId = parts[1];
+    const word = parts.slice(2).join(' ').toLowerCase().trim();
+
+    // Validate Discord ID format (should be numeric)
+    if (!/^\d+$/.test(discordId)) {
+        reply(message, 'Invalid Discord ID. It should be a numeric value.');
+        return;
+    }
+
+    if (!word || word.length < 2) {
+        reply(message, 'Word must be at least 2 characters long.');
+        return;
+    }
+
+    const username = toID(message.author?.name);
+
+    // Check if highlight already exists
+    db.get(
+        'SELECT * FROM word_highlights WHERE user = ? AND word = ?',
+        [username, word],
+        (err: Error | null, row: Highlight | undefined) => {
+            if (err) {
+                logger.error({ cmd: 'addHighlight', error: err.message });
+                reply(message, 'Error adding highlight.');
+                return;
+            }
+
+            if (row) {
+                reply(message, `You already have a highlight for "${word}".`);
+                return;
+            }
+
+            // Add the highlight
+            db.run(
+                'INSERT INTO word_highlights (user, discord_id, word) VALUES (?, ?, ?)',
+                [username, discordId, word],
+                (err: Error | null) => {
+                    if (err) {
+                        logger.error({ cmd: 'addHighlight', error: err.message });
+                        reply(message, 'Error adding highlight.');
+                        return;
+                    }
+
+                    reply(message, `Added highlight for "${word}". You'll be pinged on Discord when it's mentioned.`);
+                    logger.info({ cmd: 'addHighlight', user: username, discord_id: discordId, word });
+                }
+            );
+        }
+    );
+}
+
+/**
+ * Remove a highlight word for the current user
+ */
+export function removeHighlight(message: Message<'chat' | 'pm'>) {
+    // Parse command: #removehighlight <word>
+    const parts = message.content.split(' ');
+
+    if (parts.length < 2) {
+        reply(message, 'Usage: removehighlight <word>');
+        return;
+    }
+
+    const word = parts.slice(1).join(' ').toLowerCase().trim();
+    const username = toID(message.author?.name);
+
+    db.run(
+        'DELETE FROM word_highlights WHERE user = ? AND word = ?',
+        [username, word],
+        function(this: { changes: number }, err: Error | null) {
+            if (err) {
+                logger.error({ cmd: 'removeHighlight', error: err.message });
+                reply(message, 'Error removing highlight.');
+                return;
+            }
+
+            if (this.changes === 0) {
+                reply(message, `You don't have a highlight for "${word}".`);
+                return;
+            }
+
+            reply(message, `Removed highlight for "${word}".`);
+            logger.info({ cmd: 'removeHighlight', user: username, word });
+        }
+    );
+}
+
+/**
+ * List all highlights for the current user
+ */
+export function listHighlights(message: Message<'chat' | 'pm'>) {
+    const username = toID(message.author?.name);
+
+    db.all(
+        'SELECT word, discord_id FROM word_highlights WHERE user = ? ORDER BY word',
+        [username],
+        (err: Error | null, rows: Highlight[]) => {
+            if (err) {
+                logger.error({ cmd: 'listHighlights', error: err.message });
+                reply(message, 'Error fetching highlights.');
+                return;
+            }
+
+            if (rows.length === 0) {
+                reply(message, 'You have no highlights set.');
+                return;
+            }
+
+            const wordList = rows.map(r => r.word).join(', ');
+            const discordId = rows[0].discord_id;
+            reply(message, `Your highlights (pinging <@${discordId}>): ${wordList}`);
+        }
+    );
+}
+
+/**
+ * Escape special regex characters
+ */
+function escapeRegex(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/mods/wordHighlight.ts
+++ b/src/mods/wordHighlight.ts
@@ -32,9 +32,9 @@ export function checkHighlights(message: Message<'chat' | 'pm'>, authorUsername:
             const wordRegex = new RegExp(`\\b${escapeRegex(highlight.word)}\\b`, 'i');
             if (wordRegex.test(content)) {
                 // Send Discord notification
-                const roomInfo = message.target instanceof Object && 'roomid' in message.target
-                    ? `room: ${message.target.roomid}`
-                    : 'PM';
+                const roomInfo = message.target instanceof Object && 'roomid' in message.target ?
+                    `room: ${message.target.roomid}` :
+                    'PM';
 
                 hook.send(`<@${highlight.discord_id}> Your highlight word "${highlight.word}" was mentioned by ${message.author?.name} in ${roomInfo}: "${message.content}"`);
 
@@ -43,7 +43,7 @@ export function checkHighlights(message: Message<'chat' | 'pm'>, authorUsername:
                     user: highlight.user,
                     word: highlight.word,
                     author: message.author?.name,
-                    content: message.content
+                    content: message.content,
                 });
             }
         }
@@ -131,7 +131,7 @@ export function removeHighlight(message: Message<'chat' | 'pm'>) {
     db.run(
         'DELETE FROM word_highlights WHERE user = ? AND word = ?',
         [username, word],
-        function(this: { changes: number }, err: Error | null) {
+        function (this: { changes: number }, err: Error | null) {
             if (err) {
                 logger.error({ cmd: 'removeHighlight', error: err.message });
                 reply(message, 'Error removing highlight.');

--- a/src/mods/wordHighlight.ts
+++ b/src/mods/wordHighlight.ts
@@ -4,6 +4,7 @@ import { reply } from '../bot.js';
 import { hook } from '../hook.js';
 import { logger } from '../logger.js';
 import { toID } from 'ps-client/tools.js';
+import { config } from '../config.js';
 
 interface Highlight {
     user: string;
@@ -54,25 +55,26 @@ export function checkHighlights(message: Message<'chat' | 'pm'>, authorUsername:
  * Add a word to highlight for the current user
  */
 export function addHighlight(message: Message<'chat' | 'pm'>) {
-    // Parse command: #addhighlight <discord_id> <word>
+    // Parse command: #addhighlight <word>
     const parts = message.content.split(' ');
 
-    if (parts.length < 3) {
-        reply(message, 'Usage: addhighlight <discord_id> <word>. Example: addhighlight 123456789 pizza');
+    if (parts.length < 2) {
+        reply(message, 'Usage: addhighlight <word>. Example: addhighlight pizza');
         return;
     }
 
-    const discordId = parts[1];
-    const word = parts.slice(2).join(' ').toLowerCase().trim();
-
-    // Validate Discord ID format (should be numeric)
-    if (!/^\d+$/.test(discordId)) {
-        reply(message, 'Invalid Discord ID. It should be a numeric value.');
-        return;
-    }
+    const word = parts.slice(1).join(' ').toLowerCase().trim();
 
     if (!word || word.length < 2) {
         reply(message, 'Word must be at least 2 characters long.');
+        return;
+    }
+
+    // Get Discord ID from environment variable
+    const discordId = config.discordId;
+    if (!discordId) {
+        reply(message, 'Discord ID not configured. Please set discord_id environment variable.');
+        logger.error({ cmd: 'addHighlight', error: 'discord_id not configured' });
         return;
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,6 +73,9 @@ export const commands = [
     'addpc',
     'pc',
     'pcall',
+    'addhighlight', 'highlight',
+    'removehighlight', 'delhighlight',
+    'listhighlight', 'highlights',
 ] as const;
 
 export type Command = typeof commands[number];


### PR DESCRIPTION
This feature allows users to define words they want to be notified about in chat. When those words are mentioned by others, the bot sends a Discord ping to the user.

Features:
- Add highlights with #addhighlight <discord_id> <word>
- Remove highlights with #removehighlight <word>
- List highlights with #listhighlight
- Automatic Discord notifications when highlighted words are mentioned
- Case-insensitive whole-word matching
- Database persistence for highlight configurations

Changes:
- Added word_highlights table to database schema
- Created wordHighlight mod with add/remove/list functionality
- Added passive message monitoring to check for highlighted words
- Integrated Discord webhook notifications
